### PR TITLE
add variables endpoint to get call variables by uuid

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,13 +43,12 @@ ami.on("newexten", (event) => {
       calls[event.linkedid].uuid = value;
     }
 
-    if (event.appdata && event.appdata.includes("CALLED_NUM")) {
-      const value = event.appdata.split("=")[1];
-      calls[event.linkedid].called_num = value;
+    if (event.appdata && event.appdata.startsWith("AVR_")) {
+      const data = event.appdata.split("=");
+      const name = data[0].replace("AVR_", "").toLowerCase(); // Normalize the variable name
+      const value = data[1];
+      calls[event.linkedid][name] = value;
     }
-
-    // Other variables can be setted in extensions.conf and accessed here
-    // ...
   }
 });
 

--- a/index.js
+++ b/index.js
@@ -33,6 +33,24 @@ ami.on("newexten", (event) => {
       channel: event.channel,
     };
   }
+
+  if (event.application && event.application.toLowerCase() === "set") {
+    calls[event.linkedid] = calls[event.linkedid] || {};
+    calls[event.linkedid].channel = event.channel;
+
+    if (event.appdata && event.appdata.includes("UUID")) {
+      const value = event.appdata.split("=")[1];
+      calls[event.linkedid].uuid = value;
+    }
+
+    if (event.appdata && event.appdata.includes("CALLED_NUM")) {
+      const value = event.appdata.split("=")[1];
+      calls[event.linkedid].called_num = value;
+    }
+
+    // Other variables can be setted in extensions.conf and accessed here
+    // ...
+  }
 });
 
 // call
@@ -143,9 +161,48 @@ const handleOriginate = async (req, res) => {
   }
 };
 
+/**
+ * Handle variable requests
+ * This endpoint retrieves the variables of a call by its UUID.
+ * If no UUID is provided, it returns the last call.
+ * @param {Object} req - The request object
+ * @param {string} req.body.uuid - The UUID of the call to get the variable from
+ * @param {Object} res - The response object
+ * @returns {Object} The response object
+ */
+const handleVariables = async (req, res) => {
+  const { uuid } = req.body;
+
+  try {
+    console.log("Calling ami variables action by uuid:", uuid);
+
+    // If no UUID is provided, return the last call
+    if (!uuid) {
+      if (Object.keys(calls).length === 0) {
+        return res.status(400).json({ message: "No calls found." });
+      }
+      const lastCall = Object.values(calls).pop();
+      if (!lastCall) {
+        return res.status(400).json({ message: "No calls found." });
+      }
+      return res.status(200).json(lastCall);
+    }
+
+    const call = findCallByUUID(calls, uuid);
+    if (!call) {
+      return res.status(404).json({ message: `Call with UUID "${uuid}" not found.` });
+    }
+    return res.status(200).json(call);
+  } catch (error) {
+    console.log("Error calling Ami Variables Action:", error.message);
+    res.status(500).json({ message: "Error communicating with Asterisk" });
+  }
+};
+
 app.post("/hangup", handleHangup);
 app.post("/transfer", handleTransfer);
 app.post("/originate", handleOriginate);
+app.post("/variables", handleVariables);
 
 const port = process.env.PORT || 6006;
 app.listen(port, () => {


### PR DESCRIPTION
To be able to get variables these steps need to be followed:

Firstly, you need to add your variables where outbound call file created. Here is my config:
```
const callFileContent = `Channel: PJSIP/${number}@netgsm-trunk
CallerID: xxxxxxx
MaxRetries: 0
RetryTime: 20
WaitTime: 30
Context: avr
Extension: ${number}
Priority: 1
Set: ARG1=127.0.0.1:5001
Set: ARG2=${number}
`;
```

Second, you need to set these variables in extentions.conf. Here is my config:

```
[avr]
exten => _X.,1,Answer()
 same => n,Ringing()
 same => n,Wait(1)
 same => n,Set(UUID=${SHELL(uuidgen | tr -d '\n')})
 same => n,Set(AVR_CALLED_NUM=${ARG2})
 same => n,Dial(AudioSocket/${ARG1}/${UUID}/${AVR_CALLED_NUM})
 same => n,Hangup()
```